### PR TITLE
Update body.html

### DIFF
--- a/published/building-bitcoind-from-source-on-ubuntu/body.html
+++ b/published/building-bitcoind-from-source-on-ubuntu/body.html
@@ -33,6 +33,7 @@ apt-get install libtool autotools-dev autoconf
 apt-get install libssl-dev
 apt-get install libboost-all-dev libdb4.8-dev libdb4.8++-dev
 apt-get install pkg-config
+apt-get install bsdmainutils
 </pre>
 <p>If you're reading this from the future, you may want to check with the readme file(s) to verify that you have all the required dependencies; they may have changed since this article was written.</p>
 


### PR DESCRIPTION
bsdmainutils provides 'hexdump', which is required for a ./configure --with-gui=no.

see also: http://www.kossboss.com/linux---missing-hexdump---install-hexdump-on-debian

(This is for v0.10.0, straight inside a cloned repository)